### PR TITLE
Add gitignore for Expo and TypeScript artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.expo/
+*.expo*
+.env*


### PR DESCRIPTION
## Summary
- add gitignore for common Expo and TypeScript build artifacts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a05c72a640833196c8a7f802ae34fb