### PR TITLE
docs: add development setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,23 @@ Agrow is a mobile plant management and sharing application focused on agave plan
 
 For a comprehensive overview of the project requirements, see [docs/requirements.md](docs/requirements.md).
 
-## Development setup
+## Prerequisites
 
-1. Install dependencies:
-   ```bash
-   npm install
-   ```
-2. Start the application:
-   ```bash
-   npm start
-   ```
+- [Node.js](https://nodejs.org/)
+- [Expo](https://docs.expo.dev/get-started/installation/)
+
+## Installation
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+## Basic commands
+
+- `npm start` – start the development server.
+- `npm run android` – run on an Android emulator or device.
+- `npm run ios` – run on an iOS simulator or device.
+- `npm run web` – run in a web browser.
 


### PR DESCRIPTION
## Summary
- clarify development prerequisites for Node.js and Expo
- document install and basic run commands in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0616ee3608331a6e8411b80269b91