### PR TITLE
chore: ignore Expo caches and env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 
 # Expo
 .expo/
+*.expo*
 dist/
 web-build/
 expo-env.d.ts
@@ -31,6 +32,7 @@ yarn-error.*
 *.pem
 
 # local env files
+.env*
 .env*.local
 
 # typescript


### PR DESCRIPTION
## Summary
- ignore Expo cache directories and files
- ignore generic environment files

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a061e0f5e4833181f1957f653ca27f