### PR TITLE
feat: add image upload with user storage limit check

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Login from './screens/Login';
 import Shelves from './screens/Shelves';
 import Stocks from './screens/Stocks';
+import ImageDetail from './screens/ImageDetail';
 import { RootStackParamList } from './types';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -17,6 +18,7 @@ export default function App() {
         <Stack.Screen name="Login" component={Login} />
         <Stack.Screen name="Shelves" component={Shelves} />
         <Stack.Screen name="Stocks" component={Stocks} />
+        <Stack.Screen name="ImageDetail" component={ImageDetail} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,0 +1,22 @@
+import { supabase, PLANT_IMAGES_BUCKET, MAX_STORAGE_BYTES } from '../supabaseClient';
+
+export async function ensurePlantImagesBucket() {
+  const { data } = await supabase.storage.getBucket(PLANT_IMAGES_BUCKET);
+  if (!data) {
+    await supabase.storage.createBucket(PLANT_IMAGES_BUCKET, { public: false });
+  }
+}
+
+export async function getUserUsedBytes(userId: string): Promise<number> {
+  const { data, error } = await supabase.storage.from(PLANT_IMAGES_BUCKET).list(userId, {
+    limit: 1000,
+    offset: 0,
+  });
+  if (error || !data) return 0;
+  return data.reduce((sum, item) => sum + (item.metadata?.size ?? 0), 0);
+}
+
+export async function canUpload(userId: string, newSize: number): Promise<boolean> {
+  const used = await getUserUsedBytes(userId);
+  return used + newSize <= MAX_STORAGE_BYTES;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.25",
+        "@supabase/supabase-js": "^2.55.0",
         "expo": "~53.0.20",
+        "expo-image-picker": "^16.1.4",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.5",
@@ -2658,6 +2660,80 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.1.tgz",
+      "integrity": "sha512-edRFa2IrQw50kNntvUyS38hsL7t2d/psah6om6aNTLLcWem0R6bOUq7sk7DsGeSlNfuwEwWn57FdYSva6VddYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.11.0.tgz",
+      "integrity": "sha512-Y+kx/wDgd4oasAgoAq0bsbQojwQ+ejIif8uczZ9qufRHWFLMU5cODT+ApHsSrDufqUcVKt+eyxtOXSkeh2v9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.55.0.tgz",
+      "integrity": "sha512-Y1uV4nEMjQV1x83DGn7+Z9LOisVVRlY1geSARrUHbXWgbyKLZ6/08dvc0Us1r6AJ4tcKpwpCZWG9yDQYo1JgHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.15.1",
+        "@supabase/storage-js": "^2.10.4"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2741,6 +2817,12 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.0.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
@@ -2756,6 +2838,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -4126,6 +4217,27 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {
@@ -7854,6 +7966,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -8097,6 +8215,16 @@
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
     },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/whatwg-url-without-unicode": {
       "version": "8.0.0-3",
       "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
@@ -8110,6 +8238,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/whatwg-url/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.25",
+    "@supabase/supabase-js": "^2.55.0",
     "expo": "~53.0.20",
+    "expo-image-picker": "^16.1.4",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-native": "0.79.5",

--- a/screens/ImageDetail.tsx
+++ b/screens/ImageDetail.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+import { supabase } from '../supabaseClient';
+
+type Props = {
+  route: { params: { imageId: string } };
+};
+
+export default function ImageDetail({ route }: Props) {
+  const { imageId } = route.params;
+  const [shotAt, setShotAt] = useState('');
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase
+        .from('images')
+        .select('shot_at')
+        .eq('id', imageId)
+        .single();
+      if (data?.shot_at) setShotAt(data.shot_at);
+    };
+    load();
+  }, [imageId]);
+
+  const save = async () => {
+    await supabase.from('images').update({ shot_at: shotAt }).eq('id', imageId);
+    alert('Saved');
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <TextInput
+        value={shotAt}
+        onChangeText={setShotAt}
+        style={{ borderWidth: 1, padding: 4, marginBottom: 8 }}
+      />
+      <Button title="Save" onPress={save} />
+    </View>
+  );
+}

--- a/screens/Stocks.tsx
+++ b/screens/Stocks.tsx
@@ -1,10 +1,86 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useState } from 'react';
+import { View, Text, Button, Image, TextInput } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { supabase, PLANT_IMAGES_BUCKET } from '../supabaseClient';
+import { canUpload, ensurePlantImagesBucket } from '../lib/storage';
 
 export default function Stocks() {
+  const [image, setImage] = useState<ImagePicker.ImagePickerAsset | null>(null);
+  const [shotAt, setShotAt] = useState('');
+  const [memo, setMemo] = useState('');
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      exif: true,
+    });
+    if (!result.canceled) {
+      const asset = result.assets[0];
+      setImage(asset);
+      const exifDate = (asset.exif as any)?.DateTimeOriginal;
+      if (exifDate) {
+        const parsed = new Date(exifDate.replace(/:/g, '-').replace(' ', 'T'));
+        setShotAt(parsed.toISOString());
+      } else {
+        setShotAt(new Date().toISOString());
+      }
+    }
+  };
+
+  const upload = async () => {
+    if (!image) return;
+    const { data: userData } = await supabase.auth.getUser();
+    const user = userData.user;
+    if (!user) return;
+    await ensurePlantImagesBucket();
+    const size = image.fileSize ?? 0;
+    const allowed = await canUpload(user.id, size);
+    if (!allowed) {
+      alert('Storage limit exceeded');
+      return;
+    }
+    const ext = image.fileName?.split('.').pop() || 'jpg';
+    const filePath = `${user.id}/${Date.now()}.${ext}`;
+    const file = await fetch(image.uri);
+    const blob = await file.blob();
+    const { error: uploadError } = await supabase.storage
+      .from(PLANT_IMAGES_BUCKET)
+      .upload(filePath, blob);
+    if (uploadError) {
+      alert('Upload failed');
+      return;
+    }
+    await supabase.from('images').insert({
+      user_id: user.id,
+      path: filePath,
+      shot_at: shotAt,
+      memo,
+    });
+    alert('Uploaded');
+    setImage(null);
+    setShotAt('');
+    setMemo('');
+  };
+
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text>Stocks Screen</Text>
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 16 }}>
+      {image && (
+        <Image source={{ uri: image.uri }} style={{ width: 200, height: 200 }} />
+      )}
+      <Button title="Pick Image" onPress={pickImage} />
+      <TextInput
+        placeholder="Shot At"
+        value={shotAt}
+        onChangeText={setShotAt}
+        style={{ borderWidth: 1, width: '100%', marginTop: 8, padding: 4 }}
+      />
+      <TextInput
+        placeholder="Memo"
+        value={memo}
+        onChangeText={setMemo}
+        style={{ borderWidth: 1, width: '100%', marginTop: 8, padding: 4 }}
+      />
+      <Button title="Upload" onPress={upload} disabled={!image} />
     </View>
   );
 }

--- a/supabaseClient.ts
+++ b/supabaseClient.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+export const PLANT_IMAGES_BUCKET = 'plant-images';
+export const MAX_STORAGE_BYTES = 500 * 1024 * 1024; // 500MB

--- a/types.ts
+++ b/types.ts
@@ -2,4 +2,5 @@ export type RootStackParamList = {
   Login: undefined;
   Shelves: undefined;
   Stocks: undefined;
+  ImageDetail: { imageId: string };
 };


### PR DESCRIPTION
## Summary
- create Supabase client and storage helpers for new `plant-images` bucket and 500MB quota
- add image upload UI on Stocks screen with EXIF shot date and memo fields
- allow editing shot date in new ImageDetail screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a066e66b9c8331baa957944d6c33db