### PR TITLE
feat: add shelves and slots management

### DIFF
--- a/db.ts
+++ b/db.ts
@@ -1,0 +1,50 @@
+import * as SQLite from 'expo-sqlite';
+
+const db = SQLite.openDatabase('agrow.db');
+
+export function initDb() {
+  db.transaction(tx => {
+    tx.executeSql(
+      'CREATE TABLE IF NOT EXISTS shelves (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, grid INTEGER, position INTEGER);'
+    );
+    tx.executeSql(
+      'CREATE TABLE IF NOT EXISTS shelf_slots (id INTEGER PRIMARY KEY AUTOINCREMENT, shelf_id INTEGER, position INTEGER, plant TEXT, FOREIGN KEY (shelf_id) REFERENCES shelves(id));'
+    );
+  });
+}
+
+export function getShelves(callback: (rows: any[]) => void) {
+  db.transaction(tx => {
+    tx.executeSql('SELECT * FROM shelves ORDER BY position ASC;', [], (_t, { rows }) => {
+      callback(rows._array);
+    });
+  });
+}
+
+export function saveShelfOrder(shelves: any[]) {
+  db.transaction(tx => {
+    shelves.forEach((shelf, index) => {
+      tx.executeSql('UPDATE shelves SET position = ? WHERE id = ?', [index, shelf.id]);
+    });
+  });
+}
+
+export function getSlots(shelfId: number, callback: (rows: any[]) => void) {
+  db.transaction(tx => {
+    tx.executeSql(
+      'SELECT * FROM shelf_slots WHERE shelf_id = ? ORDER BY position ASC;',
+      [shelfId],
+      (_t, { rows }) => callback(rows._array)
+    );
+  });
+}
+
+export function saveSlotOrder(shelfId: number, slots: any[]) {
+  db.transaction(tx => {
+    slots.forEach((slot, index) => {
+      tx.executeSql('UPDATE shelf_slots SET position = ? WHERE id = ?', [index, slot.id]);
+    });
+  });
+}
+
+export default db;

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.5",
+        "react-native-draggable-flatlist": "^4.0.3",
         "react-native-safe-area-context": "^5.6.0",
         "react-native-screens": "^4.14.1"
       },
@@ -1349,6 +1350,22 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-template-literals": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+      "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
@@ -1494,6 +1511,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/hammerjs": "^2.0.36"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@expo/cli": {
@@ -2707,6 +2737,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -4448,6 +4485,23 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/hosted-git-info": {
       "version": "7.0.2",
@@ -6654,11 +6708,41 @@
         }
       }
     },
+    "node_modules/react-native-draggable-flatlist": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-draggable-flatlist/-/react-native-draggable-flatlist-4.0.3.tgz",
+      "integrity": "sha512-2F4x5BFieWdGq9SetD2nSAR7s7oQCSgNllYgERRXXtNfSOuAGAVbDb/3H3lP0y5f7rEyNwabKorZAD/SyyNbDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/preset-typescript": "^7.17.12"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.64.0",
+        "react-native-gesture-handler": ">=2.0.0",
+        "react-native-reanimated": ">=2.8.0"
+      }
+    },
     "node_modules/react-native-edge-to-edge": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
       "integrity": "sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==",
       "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-gesture-handler": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
+      "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@egjs/hammerjs": "^2.0.17",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.2.4"
+      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -6672,6 +6756,36 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-reanimated": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.0.2.tgz",
+      "integrity": "sha512-RVD/jeTWrkloRVJmTAEtgXtihEnfA7aO6SgoaTBy3jbU1zblE3Oztq0ktVO5q/rxl96l9w2+6LLcuZ6N8D7aKQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1",
+        "semver": "7.7.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-worklets": ">=0.4.0"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -6695,6 +6809,30 @@
         "warn-once": "^0.1.0"
       },
       "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.4.1.tgz",
+      "integrity": "sha512-QXAMZ8jz0sLEoNrc3ej050z6Sd+UJ/Gef4SACeMuoLRinwHIy4uel7XtMPJZMqKhFerkwXZ7Ips5vIjnNyPDBA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
+        "convert-source-map": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0",
         "react": "*",
         "react-native": "*"
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-native": "0.79.5",
+    "react-native-draggable-flatlist": "^4.0.3",
     "react-native-safe-area-context": "^5.6.0",
     "react-native-screens": "^4.14.1"
   },

--- a/screens/Shelves.tsx
+++ b/screens/Shelves.tsx
@@ -1,14 +1,121 @@
-import React from 'react';
-import { View, Text, Button } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, Pressable } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import DraggableFlatList, { ScaleDecorator } from 'react-native-draggable-flatlist';
 import { RootStackParamList } from '../types';
+import { initDb, getShelves, saveShelfOrder, getSlots, saveSlotOrder } from '../db';
+
+interface Shelf {
+  id: number;
+  name: string;
+  grid: number;
+  position: number;
+}
+
+interface Slot {
+  id: number;
+  shelf_id: number;
+  plant: string | null;
+  position: number;
+}
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Shelves'>;
 
 export default function Shelves({ navigation }: Props) {
+  const [shelves, setShelves] = useState<Shelf[]>([]);
+  const [slots, setSlots] = useState<Slot[]>([]);
+  const [selectedShelf, setSelectedShelf] = useState<Shelf | null>(null);
+  const [editing, setEditing] = useState(false);
+
+  useEffect(() => {
+    initDb();
+    loadShelves();
+  }, []);
+
+  function loadShelves() {
+    getShelves(setShelves);
+  }
+
+  function loadSlots(shelf: Shelf) {
+    setSelectedShelf(shelf);
+    getSlots(shelf.id, setSlots);
+  }
+
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text>Shelves Screen</Text>
+    <View style={{ flex: 1 }}>
+      <DraggableFlatList
+        data={shelves}
+        keyExtractor={item => item.id.toString()}
+        onDragEnd={({ data }) => {
+          setShelves(data);
+          saveShelfOrder(data);
+        }}
+        renderItem={({ item, drag, isActive }) => (
+          <ScaleDecorator>
+            <Pressable
+              onLongPress={drag}
+              onPress={() => loadSlots(item)}
+              style={{ padding: 16, backgroundColor: isActive ? '#eee' : '#fff' }}
+            >
+              <Text>{item.name}</Text>
+            </Pressable>
+          </ScaleDecorator>
+        )}
+      />
+      {selectedShelf && (
+        <View style={{ flex: 1 }}>
+          <Button
+            title={editing ? 'Done' : 'Edit'}
+            onPress={() => setEditing(!editing)}
+          />
+          {editing ? (
+            <DraggableFlatList
+              data={slots}
+              numColumns={selectedShelf.grid}
+              keyExtractor={item => item.id.toString()}
+              onDragEnd={({ data }) => {
+                setSlots(data);
+                saveSlotOrder(selectedShelf.id, data);
+              }}
+              renderItem={({ item, drag, isActive }) => (
+                <ScaleDecorator>
+                  <Pressable
+                    onLongPress={drag}
+                    style={{
+                      flex: 1,
+                      height: 80,
+                      margin: 4,
+                      backgroundColor: isActive ? '#ddd' : '#fafafa',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <Text>{item.plant || 'Empty'}</Text>
+                  </Pressable>
+                </ScaleDecorator>
+              )}
+            />
+          ) : (
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+              {slots.map(slot => (
+                <View
+                  key={slot.id}
+                  style={{
+                    width: `${100 / selectedShelf.grid}%`,
+                    height: 80,
+                    margin: 4,
+                    backgroundColor: '#fafafa',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <Text>{slot.plant || 'Empty'}</Text>
+                </View>
+              ))}
+            </View>
+          )}
+        </View>
+      )}
       <Button title="Go to Stocks" onPress={() => navigation.navigate('Stocks')} />
     </View>
   );


### PR DESCRIPTION
## Summary
- add local SQLite tables for shelves and shelf slots
- implement shelf list with drag-and-drop sorting and slot editing
- include draggable-flatlist for long-press repositioning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a066e932c48331aeb43751c07b766d