### PR TITLE
Add parent-child stock relationships with recursive tree view

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,19 +5,28 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Login from './screens/Login';
 import Shelves from './screens/Shelves';
 import Stocks from './screens/Stocks';
+import StockDetail from './screens/StockDetail';
+import StockForm from './screens/StockForm';
+import ParentSelect from './screens/ParentSelect';
 import { RootStackParamList } from './types';
+import { StockProvider } from './StockContext';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function App() {
   const scheme = useColorScheme();
   return (
-    <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack.Navigator initialRouteName="Login">
-        <Stack.Screen name="Login" component={Login} />
-        <Stack.Screen name="Shelves" component={Shelves} />
-        <Stack.Screen name="Stocks" component={Stocks} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <StockProvider>
+      <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack.Navigator initialRouteName="Login">
+          <Stack.Screen name="Login" component={Login} />
+          <Stack.Screen name="Shelves" component={Shelves} />
+          <Stack.Screen name="Stocks" component={Stocks} />
+          <Stack.Screen name="StockDetail" component={StockDetail} />
+          <Stack.Screen name="StockForm" component={StockForm} />
+          <Stack.Screen name="ParentSelect" component={ParentSelect} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </StockProvider>
   );
 }

--- a/StockContext.tsx
+++ b/StockContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export type Stock = {
+  id: number;
+  name: string;
+  parent_id: number | null;
+};
+
+type StockContextType = {
+  stocks: Stock[];
+  addStock: (name: string, parent_id: number | null) => void;
+  setParent: (id: number, parent_id: number | null) => void;
+};
+
+const StockContext = createContext<StockContextType>({
+  stocks: [],
+  addStock: () => {},
+  setParent: () => {},
+});
+
+let nextId = 1;
+
+export function StockProvider({ children }: { children: React.ReactNode }) {
+  const [stocks, setStocks] = useState<Stock[]>([]);
+
+  const addStock = (name: string, parent_id: number | null) => {
+    setStocks(prev => [...prev, { id: nextId++, name, parent_id }]);
+  };
+
+  const setParent = (id: number, parent_id: number | null) => {
+    setStocks(prev => prev.map(s => (s.id === id ? { ...s, parent_id } : s)));
+  };
+
+  return (
+    <StockContext.Provider value={{ stocks, addStock, setParent }}>
+      {children}
+    </StockContext.Provider>
+  );
+}
+
+export const useStocks = () => useContext(StockContext);

--- a/screens/ParentSelect.tsx
+++ b/screens/ParentSelect.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View, Text, FlatList, TouchableOpacity } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../types';
+import { useStocks } from '../StockContext';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'ParentSelect'>;
+
+export default function ParentSelect({ route, navigation }: Props) {
+  const { stockId } = route.params;
+  const { stocks, setParent } = useStocks();
+  const options = stocks.filter(s => s.id !== stockId);
+
+  const handleSelect = (parent_id: number | null) => {
+    setParent(stockId, parent_id);
+    navigation.goBack();
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={options}
+        keyExtractor={item => item.id.toString()}
+        renderItem={({ item }) => (
+          <TouchableOpacity onPress={() => handleSelect(item.id)}>
+            <Text style={{ fontSize: 18, marginVertical: 8 }}>{item.name}</Text>
+          </TouchableOpacity>
+        )}
+        ListHeaderComponent={
+          <TouchableOpacity onPress={() => handleSelect(null)}>
+            <Text style={{ fontSize: 18, marginVertical: 8 }}>No Parent</Text>
+          </TouchableOpacity>
+        }
+      />
+    </View>
+  );
+}

--- a/screens/StockDetail.tsx
+++ b/screens/StockDetail.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { View, Text, Button, TouchableOpacity } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../types';
+import { useStocks } from '../StockContext';
+
+function StockTree({ id, navigation }: { id: number; navigation: any }) {
+  const { stocks } = useStocks();
+  const children = stocks.filter(s => s.parent_id === id);
+  if (children.length === 0) return null;
+  return (
+    <View style={{ marginLeft: 16 }}>
+      {children.map(child => (
+        <View key={child.id} style={{ marginVertical: 4 }}>
+          <TouchableOpacity onPress={() => navigation.navigate('StockDetail', { id: child.id })}>
+            <Text>{child.name}</Text>
+          </TouchableOpacity>
+          <StockTree id={child.id} navigation={navigation} />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+type Props = NativeStackScreenProps<RootStackParamList, 'StockDetail'>;
+
+export default function StockDetail({ route, navigation }: Props) {
+  const { id } = route.params;
+  const { stocks } = useStocks();
+  const stock = stocks.find(s => s.id === id);
+  if (!stock) {
+    return (
+      <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+        <Text>Stock not found</Text>
+      </View>
+    );
+  }
+  const parent = stocks.find(s => s.id === stock.parent_id);
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text style={{ fontSize: 24, marginBottom: 16 }}>{stock.name}</Text>
+      {parent ? (
+        <TouchableOpacity onPress={() => navigation.navigate('ParentSelect', { stockId: stock.id })}>
+          <Text>Parent: {parent.name} (Change)</Text>
+        </TouchableOpacity>
+      ) : (
+        <TouchableOpacity onPress={() => navigation.navigate('ParentSelect', { stockId: stock.id })}>
+          <Text>Select Parent</Text>
+        </TouchableOpacity>
+      )}
+      <Button title="Add Child" onPress={() => navigation.navigate('StockForm', { parentId: stock.id })} />
+      <StockTree id={stock.id} navigation={navigation} />
+    </View>
+  );
+}

--- a/screens/StockForm.tsx
+++ b/screens/StockForm.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { View, TextInput, Button } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../types';
+import { useStocks } from '../StockContext';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'StockForm'>;
+
+export default function StockForm({ route, navigation }: Props) {
+  const parentId = route.params?.parentId ?? null;
+  const { addStock } = useStocks();
+  const [name, setName] = useState('');
+
+  const handleAdd = () => {
+    addStock(name, parentId);
+    navigation.goBack();
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <TextInput
+        placeholder="Name"
+        value={name}
+        onChangeText={setName}
+        style={{ borderWidth: 1, marginBottom: 16, padding: 8 }}
+      />
+      <Button title="Save" onPress={handleAdd} disabled={!name} />
+    </View>
+  );
+}

--- a/screens/Stocks.tsx
+++ b/screens/Stocks.tsx
@@ -1,10 +1,28 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, FlatList, TouchableOpacity, Button } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../types';
+import { useStocks } from '../StockContext';
 
-export default function Stocks() {
+type Props = NativeStackScreenProps<RootStackParamList, 'Stocks'>;
+
+export default function Stocks({ navigation }: Props) {
+  const { stocks } = useStocks();
+  const roots = stocks.filter(s => s.parent_id === null);
+
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-      <Text>Stocks Screen</Text>
+    <View style={{ flex: 1, padding: 16 }}>
+      <FlatList
+        data={roots}
+        keyExtractor={item => item.id.toString()}
+        renderItem={({ item }) => (
+          <TouchableOpacity onPress={() => navigation.navigate('StockDetail', { id: item.id })}>
+            <Text style={{ fontSize: 18, marginVertical: 8 }}>{item.name}</Text>
+          </TouchableOpacity>
+        )}
+        ListEmptyComponent={<Text>No stocks yet</Text>}
+      />
+      <Button title="Add Stock" onPress={() => navigation.navigate('StockForm')} />
     </View>
   );
 }

--- a/types.ts
+++ b/types.ts
@@ -2,4 +2,7 @@ export type RootStackParamList = {
   Login: undefined;
   Shelves: undefined;
   Stocks: undefined;
+  StockDetail: { id: number };
+  StockForm: { parentId?: number } | undefined;
+  ParentSelect: { stockId: number };
 };


### PR DESCRIPTION
## Summary
- add `parent_id` to stocks and context for hierarchical relationships
- link parent stock detail to child creation form and parent selector
- show unlimited generations via recursive tree component

## Testing
- `npm test`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a066e98834833196ebb0842840f14a