### PR TITLE
feat: add timeline posts with reactions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Login from './screens/Login';
 import Shelves from './screens/Shelves';
 import Stocks from './screens/Stocks';
+import Timeline from './screens/Timeline';
 import { RootStackParamList } from './types';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -17,6 +18,7 @@ export default function App() {
         <Stack.Screen name="Login" component={Login} />
         <Stack.Screen name="Shelves" component={Shelves} />
         <Stack.Screen name="Stocks" component={Stocks} />
+        <Stack.Screen name="Timeline" component={Timeline} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/db.ts
+++ b/db.ts
@@ -1,0 +1,93 @@
+import * as SQLite from 'expo-sqlite';
+
+export type Post = {
+  id: number;
+  text: string;
+  images: string[];
+};
+
+const db = SQLite.openDatabase('agrow.db');
+
+export const initDB = () => {
+  db.transaction(tx => {
+    tx.executeSql(
+      `CREATE TABLE IF NOT EXISTS timeline_posts (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        text TEXT NOT NULL,
+        images TEXT
+      );`
+    );
+    tx.executeSql(
+      `CREATE TABLE IF NOT EXISTS timeline_reactions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        post_id INTEGER NOT NULL,
+        type TEXT NOT NULL,
+        content TEXT
+      );`
+    );
+  });
+};
+
+export const fetchPosts = (offset: number, limit: number, callback: (posts: Post[]) => void) => {
+  db.transaction(tx => {
+    tx.executeSql(
+      'SELECT * FROM timeline_posts ORDER BY id DESC LIMIT ? OFFSET ?;',
+      [limit, offset],
+      (_, { rows }) => {
+        const data = rows._array.map((row: any) => ({
+          id: row.id,
+          text: row.text,
+          images: row.images ? JSON.parse(row.images) : []
+        }));
+        callback(data);
+      }
+    );
+  });
+};
+
+export const addPost = (text: string, images: string[], callback?: () => void) => {
+  db.transaction(tx => {
+    tx.executeSql('INSERT INTO timeline_posts (text, images) VALUES (?, ?);', [text, JSON.stringify(images)], () => callback && callback());
+  });
+};
+
+export const updatePost = (id: number, text: string, images: string[], callback?: () => void) => {
+  db.transaction(tx => {
+    tx.executeSql('UPDATE timeline_posts SET text = ?, images = ? WHERE id = ?;', [text, JSON.stringify(images), id], () => callback && callback());
+  });
+};
+
+export const deletePost = (id: number, callback?: () => void) => {
+  db.transaction(tx => {
+    tx.executeSql('DELETE FROM timeline_posts WHERE id = ?;', [id]);
+    tx.executeSql('DELETE FROM timeline_reactions WHERE post_id = ?;', [id], () => callback && callback());
+  });
+};
+
+export const addReaction = (postId: number, type: string, content?: string, callback?: () => void) => {
+  db.transaction(tx => {
+    tx.executeSql('INSERT INTO timeline_reactions (post_id, type, content) VALUES (?, ?, ?);', [postId, type, content || null], () => callback && callback());
+  });
+};
+
+export const getReactionCount = (postId: number, type: string, callback: (count: number) => void) => {
+  db.transaction(tx => {
+    tx.executeSql('SELECT COUNT(*) as count FROM timeline_reactions WHERE post_id = ? AND type = ?;', [postId, type], (_, { rows }) => callback(rows._array[0].count));
+  });
+};
+
+export const getReactionCounts = (postId: number, callback: (counts: { like: number; comment: number; repost: number }) => void) => {
+  db.transaction(tx => {
+    tx.executeSql(
+      'SELECT type, COUNT(*) as count FROM timeline_reactions WHERE post_id = ? GROUP BY type;',
+      [postId],
+      (_, { rows }) => {
+        const counts: any = { like: 0, comment: 0, repost: 0 };
+        rows._array.forEach((row: any) => {
+          counts[row.type] = row.count;
+        });
+        callback(counts);
+      }
+    );
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.25",
         "expo": "~53.0.20",
+        "expo-sqlite": "^15.2.14",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.5",
@@ -2962,6 +2963,12 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
     },
+    "node_modules/await-lock": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/await-lock/-/await-lock-2.2.2.tgz",
+      "integrity": "sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==",
+      "license": "MIT"
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -4163,6 +4170,20 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-sqlite": {
+      "version": "15.2.14",
+      "resolved": "https://registry.npmjs.org/expo-sqlite/-/expo-sqlite-15.2.14.tgz",
+      "integrity": "sha512-6tWnEE0fcir30/e7eVwjeC7eKdncfVnIgo2JvnKpRndedyiFMXLMyOQWNVGnuhnSrPV2BHvGGjLByS/j5VgH4w==",
+      "license": "MIT",
+      "dependencies": {
+        "await-lock": "^2.2.2"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.25",
     "expo": "~53.0.20",
+    "expo-sqlite": "^15.2.14",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-native": "0.79.5",

--- a/screens/Login.tsx
+++ b/screens/Login.tsx
@@ -10,6 +10,7 @@ export default function Login({ navigation }: Props) {
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text>Login Screen</Text>
       <Button title="Go to Shelves" onPress={() => navigation.navigate('Shelves')} />
+      <Button title="Go to Timeline" onPress={() => navigation.navigate('Timeline')} />
     </View>
   );
 }

--- a/screens/Timeline.tsx
+++ b/screens/Timeline.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, Image, Button, Alert, Share } from 'react-native';
+import { initDB, fetchPosts, getReactionCounts, addReaction, deletePost, updatePost, Post } from '../db';
+import { generateOGPMeta } from '../utils/ogp';
+
+type PostWithCounts = Post & { like: number; comment: number; repost: number };
+
+export default function Timeline() {
+  const [posts, setPosts] = useState<PostWithCounts[]>([]);
+
+  useEffect(() => {
+    initDB();
+    loadMore();
+  }, []);
+
+  const enrich = (items: Post[]): Promise<PostWithCounts[]> => {
+    return Promise.all(
+      items.map(
+        p =>
+          new Promise<PostWithCounts>(resolve =>
+            getReactionCounts(p.id, counts => resolve({ ...p, ...counts }))
+          )
+      )
+    );
+  };
+
+  const loadMore = () => {
+    fetchPosts(posts.length, 10, fetched => {
+      enrich(fetched).then(enriched => {
+        setPosts(prev => [...prev, ...enriched]);
+      });
+    });
+  };
+
+  const refresh = () => {
+    fetchPosts(0, posts.length, fetched => {
+      enrich(fetched).then(enriched => {
+        setPosts(enriched);
+      });
+    });
+  };
+
+  const handleLike = (id: number) => {
+    addReaction(id, 'like', undefined, refresh);
+  };
+
+  const handleComment = (id: number) => {
+    Alert.prompt('Comment', '', text => addReaction(id, 'comment', text, refresh));
+  };
+
+  const handleRepost = (id: number) => {
+    addReaction(id, 'repost', undefined, refresh);
+  };
+
+  const handleEdit = (post: PostWithCounts) => {
+    Alert.prompt(
+      'Edit Post',
+      '',
+      text => updatePost(post.id, text ?? post.text, post.images, refresh),
+      'plain-text',
+      post.text
+    );
+  };
+
+  const handleDelete = (id: number) => {
+    Alert.alert('Delete Post', 'Are you sure?', [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Delete', style: 'destructive', onPress: () => deletePost(id, refresh) },
+    ]);
+  };
+
+  const handleShare = (post: PostWithCounts) => {
+    const ogp = generateOGPMeta(post);
+    Share.share({ message: `${post.text}\n\n${ogp}` });
+  };
+
+  const renderPost = ({ item }: { item: PostWithCounts }) => (
+    <View style={{ padding: 16, borderBottomWidth: 1, borderColor: '#ccc' }}>
+      <Text>{item.text}</Text>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap' }}>
+        {item.images.slice(0, 4).map((uri, idx) => (
+          <Image key={idx} source={{ uri }} style={{ width: 80, height: 80, marginRight: 4, marginTop: 4 }} />
+        ))}
+      </View>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-around', marginTop: 8 }}>
+        <Button title={`Like (${item.like})`} onPress={() => handleLike(item.id)} />
+        <Button title={`Comment (${item.comment})`} onPress={() => handleComment(item.id)} />
+        <Button title={`Repost (${item.repost})`} onPress={() => handleRepost(item.id)} />
+      </View>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-around', marginTop: 8 }}>
+        <Button title="Edit" onPress={() => handleEdit(item)} />
+        <Button title="Delete" onPress={() => handleDelete(item.id)} />
+        <Button title="Share" onPress={() => handleShare(item)} />
+      </View>
+    </View>
+  );
+
+  return (
+    <FlatList
+      data={posts}
+      keyExtractor={item => item.id.toString()}
+      renderItem={renderPost}
+      onEndReached={loadMore}
+      onEndReachedThreshold={0.5}
+    />
+  );
+}

--- a/types.ts
+++ b/types.ts
@@ -2,4 +2,5 @@ export type RootStackParamList = {
   Login: undefined;
   Shelves: undefined;
   Stocks: undefined;
+  Timeline: undefined;
 };

--- a/utils/ogp.ts
+++ b/utils/ogp.ts
@@ -1,0 +1,13 @@
+import { Post } from '../db';
+
+export const generateOGPMeta = (post: Post): string => {
+  const image = post.images[0] || '';
+  const lines = [
+    `<meta property="og:title" content="Agrow Post #${post.id}" />`,
+    `<meta property="og:description" content="${post.text}" />`,
+  ];
+  if (image) {
+    lines.push(`<meta property="og:image" content="${image}" />`);
+  }
+  return lines.join('\n');
+};


### PR DESCRIPTION
## Summary
- store timeline posts and reactions in SQLite
- implement timeline screen with infinite scroll and reactions
- support editing, deleting and sharing posts with generated OGP meta

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a066eac64c83318e43fa8a70fc8349