### PR TITLE
Add search screen with tag suggestions

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Login from './screens/Login';
 import Shelves from './screens/Shelves';
 import Stocks from './screens/Stocks';
+import Search from './screens/Search';
 import { RootStackParamList } from './types';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -17,6 +18,7 @@ export default function App() {
         <Stack.Screen name="Login" component={Login} />
         <Stack.Screen name="Shelves" component={Shelves} />
         <Stack.Screen name="Stocks" component={Stocks} />
+        <Stack.Screen name="Search" component={Search} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/api.ts
+++ b/api.ts
@@ -1,0 +1,40 @@
+export interface Stock {
+  id: number;
+  name: string;
+  shelf?: string;
+  updated_at?: string;
+}
+
+export async function fetchTagSuggestions(q: string): Promise<string[]> {
+  const resp = await fetch(`/api/tags?suggest=${encodeURIComponent(q)}`);
+  if (!resp.ok) {
+    throw new Error('Failed to fetch tag suggestions');
+  }
+  return resp.json();
+}
+
+export interface SearchParams {
+  query?: string;
+  tags?: string[];
+  order?: 'updated' | 'name';
+  mineOnly?: boolean;
+}
+
+export async function searchStocks(params: SearchParams): Promise<Stock[]> {
+  const query = new URLSearchParams();
+  if (params.query) {
+    query.append('q', params.query);
+  }
+  params.tags?.forEach((t) => query.append('tag', t));
+  if (params.order) {
+    query.append('order', params.order);
+  }
+  if (params.mineOnly) {
+    query.append('mine', 'true');
+  }
+  const resp = await fetch(`/api/search?${query.toString()}`);
+  if (!resp.ok) {
+    throw new Error('Failed to search stocks');
+  }
+  return resp.json();
+}

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -1,0 +1,17 @@
+-- Basic database schema additions for tag support
+
+-- Tags are shared across all users
+create table if not exists tags (
+  id bigserial primary key,
+  name text not null unique,
+  created_at timestamptz default now()
+);
+
+-- Join table between stocks and tags for many-to-many relationship
+create table if not exists stock_tags (
+  stock_id bigint not null references stocks(id) on delete cascade,
+  tag_id bigint not null references tags(id) on delete cascade,
+  primary key (stock_id, tag_id)
+);
+
+create index if not exists tags_name_idx on tags (name);

--- a/screens/Search.tsx
+++ b/screens/Search.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  FlatList,
+  TouchableOpacity,
+  Button,
+  Switch,
+} from 'react-native';
+import { fetchTagSuggestions, searchStocks, Stock } from '../api';
+
+export default function Search() {
+  const [query, setQuery] = useState('');
+  const [tagInput, setTagInput] = useState('');
+  const [tagSuggestions, setTagSuggestions] = useState<string[]>([]);
+  const [tags, setTags] = useState<string[]>([]);
+  const [order, setOrder] = useState<'updated' | 'name'>('updated');
+  const [mineOnly, setMineOnly] = useState(false);
+  const [results, setResults] = useState<Stock[]>([]);
+
+  useEffect(() => {
+    let active = true;
+    if (tagInput.length === 0) {
+      setTagSuggestions([]);
+      return;
+    }
+    fetchTagSuggestions(tagInput)
+      .then((s) => {
+        if (active) setTagSuggestions(s);
+      })
+      .catch(() => {
+        if (active) setTagSuggestions([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, [tagInput]);
+
+  const addTag = (tag: string) => {
+    if (!tags.includes(tag)) {
+      setTags([...tags, tag]);
+    }
+    setTagInput('');
+    setTagSuggestions([]);
+  };
+
+  const performSearch = async () => {
+    try {
+      const res = await searchStocks({
+        query,
+        tags,
+        order,
+        mineOnly,
+      });
+      setResults(res);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>Tags</Text>
+      <TextInput
+        placeholder="Add tag"
+        value={tagInput}
+        onChangeText={setTagInput}
+        style={{ borderWidth: 1, marginBottom: 4, padding: 4 }}
+      />
+      {tagSuggestions.length > 0 && (
+        <FlatList
+          data={tagSuggestions}
+          keyExtractor={(item) => item}
+          renderItem={({ item }) => (
+            <TouchableOpacity onPress={() => addTag(item)}>
+              <Text style={{ padding: 4 }}>{item}</Text>
+            </TouchableOpacity>
+          )}
+        />
+      )}
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginBottom: 8 }}>
+        {tags.map((t) => (
+          <Text key={t} style={{ marginRight: 8 }}>
+            #{t}
+          </Text>
+        ))}
+      </View>
+      <Text>Stock or Shelf</Text>
+      <TextInput
+        placeholder="Search by name"
+        value={query}
+        onChangeText={setQuery}
+        style={{ borderWidth: 1, marginBottom: 8, padding: 4 }}
+      />
+      <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: 8 }}>
+        <Text>My stocks only</Text>
+        <Switch value={mineOnly} onValueChange={setMineOnly} />
+      </View>
+      <View style={{ flexDirection: 'row', marginBottom: 8 }}>
+        <Button
+          title={order === 'updated' ? 'Sort: Updated' : 'Sort: Name'}
+          onPress={() => setOrder(order === 'updated' ? 'name' : 'updated')}
+        />
+      </View>
+      <Button title="Search" onPress={performSearch} />
+      <FlatList
+        data={results}
+        keyExtractor={(item) => String(item.id)}
+        renderItem={({ item }) => (
+          <View style={{ paddingVertical: 8 }}>
+            <Text>{item.name}</Text>
+            {item.shelf && <Text style={{ color: '#666' }}>{item.shelf}</Text>}
+          </View>
+        )}
+      />
+    </View>
+  );
+}

--- a/screens/Shelves.tsx
+++ b/screens/Shelves.tsx
@@ -10,6 +10,7 @@ export default function Shelves({ navigation }: Props) {
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text>Shelves Screen</Text>
       <Button title="Go to Stocks" onPress={() => navigation.navigate('Stocks')} />
+      <Button title="Search" onPress={() => navigation.navigate('Search')} />
     </View>
   );
 }

--- a/types.ts
+++ b/types.ts
@@ -2,4 +2,5 @@ export type RootStackParamList = {
   Login: undefined;
   Shelves: undefined;
   Stocks: undefined;
+  Search: undefined;
 };


### PR DESCRIPTION
## Summary
- add tags and stock_tags tables to schema
- add API helpers for tag suggestions and stock search
- implement Search screen with tag AND search, sort options and "my stocks only" filter
- wire Search screen into navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a066ed93a88331b0eaf89ce477e25c