### PR TITLE
Add offline offline queue and retrying sync with failure notifications

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,11 +6,16 @@ import Login from './screens/Login';
 import Shelves from './screens/Shelves';
 import Stocks from './screens/Stocks';
 import { RootStackParamList } from './types';
+import { useEffect } from 'react';
+import { initSyncService } from './syncService';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function App() {
   const scheme = useColorScheme();
+  useEffect(() => {
+    initSyncService();
+  }, []);
   return (
     <NavigationContainer theme={scheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack.Navigator initialRouteName="Login">

--- a/offlineQueue.ts
+++ b/offlineQueue.ts
@@ -1,0 +1,40 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export interface OfflineOperation {
+  id: string;
+  url: string;
+  options?: RequestInit;
+  retries?: number;
+}
+
+const QUEUE_KEY = 'offline_queue';
+
+async function readQueue(): Promise<OfflineOperation[]> {
+  const data = await AsyncStorage.getItem(QUEUE_KEY);
+  return data ? JSON.parse(data) : [];
+}
+
+async function writeQueue(queue: OfflineOperation[]): Promise<void> {
+  await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+}
+
+export async function enqueue(op: OfflineOperation): Promise<void> {
+  const queue = await readQueue();
+  queue.push(op);
+  await writeQueue(queue);
+}
+
+export async function dequeue(): Promise<OfflineOperation | undefined> {
+  const queue = await readQueue();
+  const op = queue.shift();
+  await writeQueue(queue);
+  return op;
+}
+
+export async function peekQueue(): Promise<OfflineOperation[]> {
+  return readQueue();
+}
+
+export async function clearQueue(): Promise<void> {
+  await AsyncStorage.removeItem(QUEUE_KEY);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "agrow-app",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^1.23.1",
+        "@react-native-community/netinfo": "^11.3.1",
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.25",
         "expo": "~53.0.20",
@@ -2266,6 +2268,27 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.4.1.tgz",
+      "integrity": "sha512-B0BYAkghz3Q2V09BF88RA601XursIEA111tnc2JOaN7axJWmNefmfjZqw/KdSxKZp7CZUuPpjBmz/WCR9uaHYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": ">=0.59"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -4675,6 +4698,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -5412,6 +5444,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-safe-area-context": "^5.6.0",
-    "react-native-screens": "^4.14.1"
+    "react-native-screens": "^4.14.1",
+    "@react-native-async-storage/async-storage": "^1.23.1",
+    "@react-native-community/netinfo": "^11.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/supabase/functions/sync-failure-email/index.ts
+++ b/supabase/functions/sync-failure-email/index.ts
@@ -1,0 +1,22 @@
+import { serve } from "https://deno.land/std/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+serve(async (req) => {
+  const { operation, error } = await req.json();
+  const adminEmail = Deno.env.get('ADMIN_EMAIL');
+  if (!adminEmail) {
+    return new Response('Missing ADMIN_EMAIL', { status: 500 });
+  }
+
+  const supabase = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!);
+
+  await supabase.functions.invoke('send-email', {
+    body: {
+      to: adminEmail,
+      subject: 'Sync Failed',
+      content: `Operation ${operation?.id} failed: ${error}`
+    }
+  });
+
+  return new Response('ok');
+});

--- a/syncService.ts
+++ b/syncService.ts
@@ -1,0 +1,57 @@
+import NetInfo from '@react-native-community/netinfo';
+import { Alert } from 'react-native';
+import { enqueue, peekQueue, clearQueue, OfflineOperation } from './offlineQueue';
+
+const MAX_RETRIES = 3;
+const EDGE_FUNCTION_URL = '/functions/v1/sync-failure-email';
+
+async function sendOperation(op: OfflineOperation) {
+  const res = await fetch(op.url, op.options);
+  if (!res.ok) {
+    throw new Error(`Request failed: ${res.status}`);
+  }
+}
+
+async function notifyFailure(op: OfflineOperation, error: unknown) {
+  try {
+    await fetch(EDGE_FUNCTION_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ operation: op, error: String(error) })
+    });
+  } catch {
+    // ignore notification errors
+  }
+}
+
+export async function processQueue() {
+  const queue = await peekQueue();
+  await clearQueue();
+  for (const op of queue) {
+    let success = false;
+    let lastError: unknown;
+    for (let attempt = 0; attempt < MAX_RETRIES && !success; attempt++) {
+      try {
+        await sendOperation(op);
+        success = true;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    if (!success) {
+      await notifyFailure(op, lastError);
+      Alert.alert('同期に失敗しました', '再試行しますか？', [
+        { text: '再試行', onPress: () => enqueue(op) },
+        { text: '閉じる', style: 'cancel' }
+      ]);
+    }
+  }
+}
+
+export function initSyncService() {
+  NetInfo.addEventListener(state => {
+    if (state.isConnected) {
+      processQueue();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- store pending operations in AsyncStorage-backed offline queue
- automatically retry syncing when network returns and notify admins via edge function
- show retry prompt to users when sync repeatedly fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a066ee33ac8331ae67526ba29309f4