### PR TITLE
feat: stock form and private sharing safeguards

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Login from './screens/Login';
 import Shelves from './screens/Shelves';
 import Stocks from './screens/Stocks';
+import StockForm from './screens/StockForm';
 import { RootStackParamList } from './types';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -17,6 +18,7 @@ export default function App() {
         <Stack.Screen name="Login" component={Login} />
         <Stack.Screen name="Shelves" component={Shelves} />
         <Stack.Screen name="Stocks" component={Stocks} />
+        <Stack.Screen name="StockForm" component={StockForm} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.25",
         "expo": "~53.0.20",
+        "expo-image-picker": "~15.0.6",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.5",
@@ -4126,6 +4127,27 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.7.0.tgz",
+      "integrity": "sha512-cx+MxxsAMGl9AiWnQUzrkJMJH4eNOGlu7XkLGnAXSJrRoIiciGaKqzeaD326IyCTV+Z1fXvIliSgNW+DscvD8g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-15.0.7.tgz",
+      "integrity": "sha512-u8qiPZNfDb+ap6PJ8pq2iTO7JKX+ikAUQ0K0c7gXGliKLxoXgDdDmXxz9/6QdICTshJBJlBvI0MwY5NWu7A/uw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~4.7.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/native-stack": "^7.3.25",
     "expo": "~53.0.20",
     "expo-status-bar": "~2.2.3",
+    "expo-image-picker": "~15.0.6",
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-safe-area-context": "^5.6.0",

--- a/screens/StockForm.tsx
+++ b/screens/StockForm.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, Image, Alert } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList, Stock } from '../types';
+
+export default function StockForm({ route, navigation }: NativeStackScreenProps<RootStackParamList, 'StockForm'>) {
+  const editingStock: Stock | undefined = route.params?.stock;
+  const [name, setName] = useState(editingStock?.name ?? '');
+  const [imageUri, setImageUri] = useState(editingStock?.image ?? '');
+  const [tags, setTags] = useState(editingStock ? editingStock.tags.join(',') : '');
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images });
+    if (!result.canceled) {
+      setImageUri(result.assets[0].uri);
+    }
+  };
+
+  const handleSubmit = () => {
+    if (!name.trim() || !imageUri || !tags.trim()) {
+      Alert.alert('すべての項目を入力してください');
+      return;
+    }
+    // Placeholder submit logic
+    const stock: Stock = {
+      id: editingStock?.id ?? 'temp-id',
+      name,
+      image: imageUri,
+      tags: tags.split(',').map(t => t.trim()).filter(Boolean),
+      isPublic: editingStock?.isPublic ?? true,
+    };
+    console.log('Submitted stock', stock);
+    navigation.goBack();
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Text>名称</Text>
+      <TextInput value={name} onChangeText={setName} placeholder="株の名称" style={{ borderWidth: 1, marginBottom: 12, padding: 8 }} />
+
+      <Text>画像</Text>
+      {imageUri ? <Image source={{ uri: imageUri }} style={{ width: 200, height: 200, marginBottom: 12 }} /> : null}
+      <Button title="画像を選択" onPress={pickImage} />
+
+      <Text style={{ marginTop: 16 }}>タグ (カンマ区切り)</Text>
+      <TextInput value={tags} onChangeText={setTags} placeholder="例: agave, succulent" style={{ borderWidth: 1, marginBottom: 12, padding: 8 }} />
+
+      <Button title="保存" onPress={handleSubmit} />
+    </View>
+  );
+}

--- a/screens/Stocks.tsx
+++ b/screens/Stocks.tsx
@@ -1,10 +1,30 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View, Text, Button, Share } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList, Stock } from '../types';
 
-export default function Stocks() {
+const sampleStock: Stock = {
+  id: '1',
+  name: 'サンプル株',
+  image: 'https://placehold.co/600x400',
+  tags: ['agave'],
+  isPublic: false,
+};
+
+export default function Stocks({ navigation }: NativeStackScreenProps<RootStackParamList, 'Stocks'>) {
+  const shareStock = async (stock: Stock) => {
+    if (stock.isPublic) {
+      await Share.share({ message: `Check my stock ${stock.name}: https://example.com/stocks/${stock.id}`, url: stock.image });
+    } else {
+      await Share.share({ url: stock.image });
+    }
+  };
+
   return (
-    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', gap: 8 }}>
       <Text>Stocks Screen</Text>
+      <Button title="株を追加" onPress={() => navigation.navigate('StockForm')} />
+      <Button title="共有" onPress={() => shareStock(sampleStock)} />
     </View>
   );
 }

--- a/supabase/migrations/20241005_add_columns_to_stocks.sql
+++ b/supabase/migrations/20241005_add_columns_to_stocks.sql
@@ -1,0 +1,5 @@
+-- Adds name, public flag, and tag references to stocks table
+alter table stocks
+  add column name text not null,
+  add column is_public boolean not null default true,
+  add column tag_ids bigint[] not null default '{}'::bigint[];

--- a/types.ts
+++ b/types.ts
@@ -2,4 +2,13 @@ export type RootStackParamList = {
   Login: undefined;
   Shelves: undefined;
   Stocks: undefined;
+  StockForm: { stock?: Stock } | undefined;
 };
+
+export interface Stock {
+  id: string;
+  name: string;
+  image: string;
+  tags: string[];
+  isPublic: boolean;
+}


### PR DESCRIPTION
## Summary
- extend stocks table with name, public flag, and tag references
- add StockForm screen with required fields
- share private stocks without links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a066e8565483318452c1eda3293817