### PR TITLE
Add Supabase auth, account merging, and profile management

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import Login from './screens/Login';
 import Shelves from './screens/Shelves';
 import Stocks from './screens/Stocks';
+import Profile from './screens/Profile';
 import { RootStackParamList } from './types';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -17,6 +18,7 @@ export default function App() {
         <Stack.Screen name="Login" component={Login} />
         <Stack.Screen name="Shelves" component={Shelves} />
         <Stack.Screen name="Stocks" component={Stocks} />
+        <Stack.Screen name="Profile" component={Profile} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,15 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createClient } from '@supabase/supabase-js';
+import 'react-native-url-polyfill/auto';
+
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL ?? '';
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? '';
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  auth: {
+    storage: AsyncStorage,
+    autoRefreshToken: true,
+    persistSession: true,
+    detectSessionInUrl: false,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,17 @@
       "name": "agrow-app",
       "version": "1.0.0",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-navigation/native": "^7.1.17",
         "@react-navigation/native-stack": "^7.3.25",
+        "@supabase/supabase-js": "^2.55.0",
         "expo": "~53.0.20",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.5",
         "react-native-safe-area-context": "^5.6.0",
-        "react-native-screens": "^4.14.1"
+        "react-native-screens": "^4.14.1",
+        "react-native-url-polyfill": "^2.0.0"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -2268,6 +2271,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-2.2.0.tgz",
+      "integrity": "sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
     "node_modules/@react-native/assets-registry": {
       "version": "0.79.5",
       "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.5.tgz",
@@ -2658,6 +2673,80 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.71.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
+      "integrity": "sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.5.tgz",
+      "integrity": "sha512-v5GSqb9zbosquTo6gBwIiq7W9eQ7rE5QazsK/ezNiQXdCbY+bH8D9qEaBIkhVvX4ZRW5rP03gEfw5yw9tiq4EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.15",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+      "integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.15.1.tgz",
+      "integrity": "sha512-edRFa2IrQw50kNntvUyS38hsL7t2d/psah6om6aNTLLcWem0R6bOUq7sk7DsGeSlNfuwEwWn57FdYSva6VddYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.13",
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.11.0.tgz",
+      "integrity": "sha512-Y+kx/wDgd4oasAgoAq0bsbQojwQ+ejIif8uczZ9qufRHWFLMU5cODT+ApHsSrDufqUcVKt+eyxtOXSkeh2v9ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/node-fetch": "^2.6.14"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.55.0.tgz",
+      "integrity": "sha512-Y1uV4nEMjQV1x83DGn7+Z9LOisVVRlY1geSARrUHbXWgbyKLZ6/08dvc0Us1r6AJ4tcKpwpCZWG9yDQYo1JgHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.71.1",
+        "@supabase/functions-js": "2.4.5",
+        "@supabase/node-fetch": "2.6.15",
+        "@supabase/postgrest-js": "1.19.4",
+        "@supabase/realtime-js": "2.15.1",
+        "@supabase/storage-js": "^2.10.4"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2741,6 +2830,12 @@
         "undici-types": "~7.10.0"
       }
     },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.0.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
@@ -2756,6 +2851,15 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -4675,6 +4779,15 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -5412,6 +5525,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -6699,6 +6824,18 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-url-polyfill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-2.0.0.tgz",
+      "integrity": "sha512-My330Do7/DvKnEvwQc0WdcBnFPploYKp9CYlefDXzIdEaA+PAhDYllkvGeEroEzvc4Kzzj2O4yVdz8v6fjRvhA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url-without-unicode": "8.0.0-3"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
       "version": "0.79.5",
       "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.5.tgz",
@@ -7854,6 +7991,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -8097,6 +8240,16 @@
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
     },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/whatwg-url-without-unicode": {
       "version": "8.0.0-3",
       "resolved": "https://registry.npmjs.org/whatwg-url-without-unicode/-/whatwg-url-without-unicode-8.0.0-3.tgz",
@@ -8110,6 +8263,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/whatwg-url/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -11,14 +11,17 @@
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
+    "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-navigation/native": "^7.1.17",
     "@react-navigation/native-stack": "^7.3.25",
+    "@supabase/supabase-js": "^2.55.0",
     "expo": "~53.0.20",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-native": "0.79.5",
     "react-native-safe-area-context": "^5.6.0",
-    "react-native-screens": "^4.14.1"
+    "react-native-screens": "^4.14.1",
+    "react-native-url-polyfill": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/screens/Login.tsx
+++ b/screens/Login.tsx
@@ -1,15 +1,59 @@
-import React from 'react';
-import { View, Text, Button } from 'react-native';
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, ActivityIndicator, Alert } from 'react-native';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../types';
+import { supabase } from '../lib/supabase';
+import type { User } from '@supabase/supabase-js';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Login'>;
 
 export default function Login({ navigation }: Props) {
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (session?.user) handleSignedIn(session.user);
+    });
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) handleSignedIn(session.user);
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const handleSignedIn = async (user: User) => {
+    // Merge accounts by email in users table
+    const { data: existing } = await supabase
+      .from('users')
+      .select('id')
+      .eq('email', user.email)
+      .single();
+    if (existing && existing.id !== user.id) {
+      await supabase.from('users').update({ id: user.id }).eq('email', user.email!);
+    } else {
+      await supabase.from('users').upsert({ id: user.id, email: user.email });
+    }
+    // Ensure profile exists
+    await supabase.from('profiles').upsert({ id: user.id, username: user.user_metadata?.full_name || '', avatar_url: user.user_metadata?.avatar_url || '' });
+    navigation.replace('Shelves');
+  };
+
+  const signIn = async (provider: 'google' | 'twitter') => {
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithOAuth({ provider });
+    if (error) Alert.alert('Login error', error.message);
+    setLoading(false);
+  };
+
   return (
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text>Login Screen</Text>
-      <Button title="Go to Shelves" onPress={() => navigation.navigate('Shelves')} />
+      {loading && <ActivityIndicator />}
+      <Button title="Sign in with Google" onPress={() => signIn('google')} />
+      <Button title="Sign in with X" onPress={() => signIn('twitter')} />
     </View>
   );
 }

--- a/screens/Profile.tsx
+++ b/screens/Profile.tsx
@@ -1,0 +1,107 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, TextInput, Button, Image } from 'react-native';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../types';
+import { supabase } from '../lib/supabase';
+
+interface Profile {
+  id: string;
+  username: string | null;
+  avatar_url: string | null;
+  bio: string | null;
+  followers: string[] | null;
+  following: string[] | null;
+}
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Profile'>;
+
+export default function ProfileScreen({ route }: Props) {
+  const { userId } = route.params || {};
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [username, setUsername] = useState('');
+  const [bio, setBio] = useState('');
+  const [sessionUserId, setSessionUserId] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+
+  const isOwnProfile = !userId || userId === sessionUserId;
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      const uid = userId ?? session?.user.id;
+      setSessionUserId(session?.user.id ?? null);
+      if (!uid) return;
+      const { data } = await supabase.from('profiles').select('*').eq('id', uid).single();
+      if (data) {
+        setProfile(data);
+        setUsername(data.username ?? '');
+        setBio(data.bio ?? '');
+      }
+    };
+    load();
+  }, [userId]);
+
+  const save = async () => {
+    if (!sessionUserId) return;
+    const updates = { id: sessionUserId, username, bio };
+    const { data } = await supabase.from('profiles').upsert(updates).select().single();
+    if (data) {
+      setProfile(data);
+      setEditing(false);
+    }
+  };
+
+  const toggleFollow = async () => {
+    if (!profile || !sessionUserId || isOwnProfile) return;
+    const following = profile.followers?.includes(sessionUserId);
+    if (following) {
+      const newFollowers = (profile.followers || []).filter((id) => id !== sessionUserId);
+      await supabase.from('profiles').update({ followers: newFollowers }).eq('id', profile.id);
+      const { data } = await supabase.from('profiles').select('following').eq('id', sessionUserId).single();
+      const myFollowing = (data?.following || []).filter((id: string) => id !== profile.id);
+      await supabase.from('profiles').update({ following: myFollowing }).eq('id', sessionUserId);
+      setProfile({ ...profile, followers: newFollowers });
+    } else {
+      const newFollowers = [...(profile.followers || []), sessionUserId];
+      await supabase.from('profiles').update({ followers: newFollowers }).eq('id', profile.id);
+      const { data } = await supabase.from('profiles').select('following').eq('id', sessionUserId).single();
+      const myFollowing = [...(data?.following || []), profile.id];
+      await supabase.from('profiles').update({ following: myFollowing }).eq('id', sessionUserId);
+      setProfile({ ...profile, followers: newFollowers });
+    }
+  };
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      {profile ? (
+        <>
+          {profile.avatar_url ? (
+            <Image source={{ uri: profile.avatar_url }} style={{ width: 100, height: 100, borderRadius: 50 }} />
+          ) : null}
+          {editing ? (
+            <>
+              <TextInput placeholder="Username" value={username} onChangeText={setUsername} />
+              <TextInput placeholder="Bio" value={bio} onChangeText={setBio} multiline />
+              <Button title="Save" onPress={save} />
+            </>
+          ) : (
+            <>
+              <Text>{profile.username}</Text>
+              <Text>{profile.bio}</Text>
+              {isOwnProfile ? (
+                <Button title="Edit" onPress={() => setEditing(true)} />
+              ) : (
+                <Button
+                  title={profile.followers?.includes(sessionUserId ?? '') ? 'Unfollow' : 'Follow'}
+                  onPress={toggleFollow}
+                />
+              )}
+            </>
+          )}
+        </>
+      ) : (
+        <Text>No profile loaded</Text>
+      )}
+    </View>
+  );
+}

--- a/screens/Shelves.tsx
+++ b/screens/Shelves.tsx
@@ -10,6 +10,7 @@ export default function Shelves({ navigation }: Props) {
     <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
       <Text>Shelves Screen</Text>
       <Button title="Go to Stocks" onPress={() => navigation.navigate('Stocks')} />
+      <Button title="Go to Profile" onPress={() => navigation.navigate('Profile')} />
     </View>
   );
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,0 +1,18 @@
+-- Schema for custom users and profiles tables
+
+-- Users table ensures one entry per email, allowing account merging across providers
+create table if not exists users (
+  id uuid primary key,
+  email text unique not null
+);
+
+-- Profiles table stores public profile information and follow relationships
+create table if not exists profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  username text,
+  avatar_url text,
+  bio text,
+  followers uuid[] default array[]::uuid[],
+  following uuid[] default array[]::uuid[],
+  created_at timestamp with time zone default now()
+);

--- a/types.ts
+++ b/types.ts
@@ -2,4 +2,5 @@ export type RootStackParamList = {
   Login: undefined;
   Shelves: undefined;
   Stocks: undefined;
+  Profile: { userId?: string } | undefined;
 };


### PR DESCRIPTION
## Summary
- integrate Supabase client and dependencies
- add OAuth login with Google and X including user/profile upsert logic
- introduce profile schema and screen with follow & edit features

## Testing
- `npm test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a066e5707c8331a3af8a00fcee4d69