### PR TITLE
Remove expo-nfc and update Reanimated plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-worklets/plugin'],
+  };
+};

--- a/expo-nfc.d.ts
+++ b/expo-nfc.d.ts
@@ -1,1 +1,0 @@
-declare module 'expo-nfc';

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "expo-image-picker": "~16.1.4",
         "expo-linking": "^7.1.7",
         "expo-network": "~7.1.5",
-        "expo-nfc": "^0.0.0",
         "expo-notifications": "~0.31.4",
         "expo-sqlite": "~13.0.0",
         "expo-status-bar": "~2.2.3",
@@ -5111,11 +5110,6 @@
         "expo": "*",
         "react": "*"
       }
-    },
-    "node_modules/expo-nfc": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/expo-nfc/-/expo-nfc-0.0.0.tgz",
-      "integrity": "sha512-gE9hveLyVIOEQUepm55+4sssKEWhYQdirrHwl2CuLU7Nb5moTA1QRtcpvxjLQ2HFw/wXLioTOdTGqypPpK2nuw=="
     },
     "node_modules/expo-notifications": {
       "version": "0.31.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "expo-image-picker": "~16.1.4",
     "expo-linking": "^7.1.7",
     "expo-network": "~7.1.5",
-    "expo-nfc": "^0.0.0",
     "expo-notifications": "~0.31.4",
     "expo-sqlite": "~13.0.0",
     "expo-status-bar": "~2.2.3",

--- a/screens/NfcWriter.tsx
+++ b/screens/NfcWriter.tsx
@@ -1,35 +1,14 @@
-import React, { useState } from 'react';
-import { View, TextInput, Button, Text } from 'react-native';
-import * as NFC from 'expo-nfc';
+import React from 'react';
+import { View, Text } from 'react-native';
 
 export default function NfcWriter() {
-  const [stockId, setStockId] = useState('');
-  const [status, setStatus] = useState('');
-
-  const writeTag = async () => {
-    try {
-      await NFC.requestTechnologyAsync(NFC.Ndef);
-      await NFC.writeNdefMessageAsync(
-        NFC.buildNdefMessage([NFC.ndefRecords.uriRecord(`agrow://stock/${stockId}`)])
-      );
-      setStatus('タグへの書き込みに成功しました');
-    } catch (e) {
-      setStatus('書き込みに失敗しました');
-    } finally {
-      NFC.cancelTechnologyRequestAsync();
-    }
-  };
-
   return (
-    <View style={{ flex: 1, padding: 16 }}>
-      <TextInput
-        placeholder="株ID"
-        value={stockId}
-        onChangeText={setStockId}
-        style={{ borderWidth: 1, marginBottom: 16, padding: 8 }}
-      />
-      <Button title="タグへ書き込む" onPress={writeTag} />
-      <Text style={{ marginTop: 16 }}>{status}</Text>
+    <View
+      style={{ flex: 1, padding: 16, justifyContent: 'center', alignItems: 'center' }}
+    >
+      <Text>NFC書き込みは Expo Go ではサポートされていません。</Text>
+      <Text>カスタム開発ビルドでご利用ください。</Text>
     </View>
   );
 }
+


### PR DESCRIPTION
## Summary
- remove expo-nfc dependency and stub
- add babel config using react-native-worklets plugin
- replace NfcWriter screen with Expo Go unsupported message

## Testing
- `npm test`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68a0801828fc83318d7d51c47f1acc1c