### PR TITLE
feat: add docker compose for local supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+POSTGRES_PASSWORD=supabase
+JWT_SECRET=super-secret-jwt
+ANON_KEY=anon-key
+SERVICE_ROLE_KEY=service-role-key
+EXPO_PUBLIC_SUPABASE_URL=http://localhost:3000
+EXPO_PUBLIC_SUPABASE_ANON_KEY=anon-key
+

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.*
 # local env files
 .env*
 .env*.local
+!.env.example
 
 # typescript
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ The app expects the following environment variables to be defined (e.g. via a `.
 - `EXPO_PUBLIC_SUPABASE_URL` – Supabase project URL
 - `EXPO_PUBLIC_SUPABASE_ANON_KEY` – Supabase anon key
 
+## Local Supabase
+
+A `docker-compose.yml` file is provided to run Supabase locally. Copy `.env.example` to `.env` and start the stack:
+
+```bash
+cp .env.example .env
+docker compose up -d
+```
+
+The containers expose the Supabase APIs on your `localhost` so the application can connect using the values from the `.env` file. When you're done, stop the services with:
+
+```bash
+docker compose down
+```
+
 ## Project structure
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,92 @@
+version: '3.9'
+services:
+  db:
+    container_name: supabase-db
+    image: supabase/postgres:latest
+    ports:
+      - "54322:5432"
+    volumes:
+      - ./supabase:/docker-entrypoint-initdb.d
+    environment:
+      POSTGRES_PASSWORD: supabase
+
+  auth:
+    container_name: supabase-auth
+    image: supabase/gotrue:latest
+    depends_on:
+      - db
+    environment:
+      GOTRUE_DB_DRIVER: postgres
+      DATABASE_URL: postgres://postgres:supabase@db:5432/postgres
+      GOTRUE_SITE_URL: http://localhost:9999
+      API_EXTERNAL_URL: http://localhost:9999
+      GOTRUE_JWT_SECRET: super-secret-jwt
+      GOTRUE_PORT: 9999
+    ports:
+      - "9999:9999"
+
+  rest:
+    container_name: supabase-rest
+    image: postgrest/postgrest:latest
+    depends_on:
+      - db
+    environment:
+      PGRST_DB_URI: postgres://postgres:supabase@db:5432/postgres
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_DB_SCHEMA: public
+      PGRST_JWT_SECRET: super-secret-jwt
+      PGRST_SERVER_PORT: 3000
+    ports:
+      - "3000:3000"
+
+  realtime:
+    container_name: supabase-realtime
+    image: supabase/realtime:latest
+    depends_on:
+      - db
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: supabase
+      JWT_SECRET: super-secret-jwt
+      PORT: 4000
+    ports:
+      - "4000:4000"
+
+  storage:
+    container_name: supabase-storage
+    image: supabase/storage-api:latest
+    depends_on:
+      - db
+      - rest
+    environment:
+      POSTGREST_URL: http://rest:3000
+      PGRST_JWT_SECRET: super-secret-jwt
+      ANON_KEY: anon-key
+      SERVICE_KEY: service-role-key
+      PUBLIC_URL: http://localhost:5000
+      PORT: 5000
+      REGION: local
+      GLOBAL_S3_BUCKET: local-bucket
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_USER: postgres
+      DB_PASSWORD: supabase
+      DB_NAME: postgres
+    ports:
+      - "5000:5000"
+
+  studio:
+    container_name: supabase-studio
+    image: supabase/studio:latest
+    depends_on:
+      - auth
+      - rest
+      - realtime
+      - storage
+    environment:
+      SUPABASE_URL: http://localhost:3000
+      SUPABASE_ANON_KEY: anon-key
+    ports:
+      - "54323:3000"


### PR DESCRIPTION
## Summary
- add docker-compose stack for local Supabase development
- include example env file and unignore it from gitignore
- document how to start Supabase locally

## Testing
- `npm test`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a08a66ccdc8331b7c053fadc09d315