### PR TITLE
Fix worklets module init error by switching to reanimated plugin

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,3 +1,4 @@
+import 'react-native-reanimated';
 import React, { useEffect } from 'react';
 import { useColorScheme } from 'react-native';
 import * as Linking from 'expo-linking';

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    plugins: ['react-native-worklets/plugin'],
+    plugins: ['react-native-reanimated/plugin'],
   };
 };


### PR DESCRIPTION
## Summary
- use `react-native-reanimated` Babel plugin instead of obsolete `react-native-worklets` plugin
- import `react-native-reanimated` at app startup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a09094d7188331a9f9ea7ea79cbf7f