### PR TITLE
feat: enable timeline posting

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,9 +2,14 @@ import { useEffect } from 'react';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFrameworkReady } from '../hooks/useFrameworkReady';
+import { initDb } from '../db';
 
 export default function RootLayout() {
   useFrameworkReady();
+
+  useEffect(() => {
+    initDb();
+  }, []);
 
   return (
     <>

--- a/app/post/index.tsx
+++ b/app/post/index.tsx
@@ -14,6 +14,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { Camera, Image as ImageIcon, X, Hash, MapPin, ArrowLeft } from 'lucide-react-native';
 import * as ImagePicker from 'expo-image-picker';
+import { addPost } from '../../db';
 
 const { width } = Dimensions.get('window');
 
@@ -87,11 +88,10 @@ export default function PostScreen() {
       `この内容で投稿しますか？\n\n公開設定: ${isPublic ? '公開' : '非公開'}`,
       [
         { text: 'キャンセル' },
-        { 
-          text: '投稿', 
-          onPress: () => {
-            console.log('Posting:', { content, images, tags, selectedAgave, isPublic });
-            // リセット
+        {
+          text: '投稿',
+          onPress: async () => {
+            await addPost(content, images.map((img) => img.uri));
             setContent('');
             setImages([]);
             setTags('');


### PR DESCRIPTION
## Summary
- initialize SQLite database on app start
- load posts from database in timeline tab
- allow creating new posts and saving to DB

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a191ca6a88833197e5870548eaa20e