### PR TITLE
Improve local Supabase setup for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,20 +7,22 @@ services:
       - "54322:5432"
     volumes:
       - ./supabase:/docker-entrypoint-initdb.d
+    env_file: .env
     environment:
-      POSTGRES_PASSWORD: supabase
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
 
   auth:
     container_name: supabase-auth
     image: supabase/gotrue:v2.178.0
     depends_on:
       - db
+    env_file: .env
     environment:
       GOTRUE_DB_DRIVER: postgres
-      DATABASE_URL: postgres://postgres:supabase@db:5432/postgres
+      DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/postgres
       GOTRUE_SITE_URL: http://localhost:9999
       API_EXTERNAL_URL: http://localhost:9999
-      GOTRUE_JWT_SECRET: super-secret-jwt1111111111111111
+      GOTRUE_JWT_SECRET: ${JWT_SECRET}
       GOTRUE_PORT: 9999
     ports:
       - "9999:9999"
@@ -30,11 +32,12 @@ services:
     image: postgrest/postgrest:latest
     depends_on:
       - db
+    env_file: .env
     environment:
-      PGRST_DB_URI: postgres://postgres:supabase@db:5432/postgres
+      PGRST_DB_URI: postgres://postgres:${POSTGRES_PASSWORD}@db:5432/postgres
       PGRST_DB_ANON_ROLE: anon
       PGRST_DB_SCHEMA: public
-      PGRST_JWT_SECRET: super-secret-jwt1111111111111111
+      PGRST_JWT_SECRET: ${JWT_SECRET}
       PGRST_SERVER_PORT: 3000
     ports:
       - "3000:3000"
@@ -44,12 +47,13 @@ services:
     image: supabase/realtime:latest
     depends_on:
       - db
+    env_file: .env
     environment:
       DB_HOST: db
       DB_PORT: 5432
       DB_USER: postgres
-      DB_PASSWORD: supabase
-      JWT_SECRET: super-secret-jwt1111111111111111
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
       PORT: 4000
     ports:
       - "4000:4000"
@@ -60,11 +64,12 @@ services:
     depends_on:
       - db
       - rest
+    env_file: .env
     environment:
       POSTGREST_URL: http://rest:3000
-      PGRST_JWT_SECRET: super-secret-jwt1111111111111111
-      ANON_KEY: anon-key
-      SERVICE_KEY: service-role-key
+      PGRST_JWT_SECRET: ${JWT_SECRET}
+      ANON_KEY: ${ANON_KEY}
+      SERVICE_KEY: ${SERVICE_ROLE_KEY}
       PUBLIC_URL: http://localhost:5000
       PORT: 5000
       REGION: local
@@ -72,7 +77,7 @@ services:
       DB_HOST: db
       DB_PORT: 5432
       DB_USER: postgres
-      DB_PASSWORD: supabase
+      DB_PASSWORD: ${POSTGRES_PASSWORD}
       DB_NAME: postgres
     ports:
       - "5000:5000"
@@ -85,8 +90,9 @@ services:
       - rest
       - realtime
       - storage
+    env_file: .env
     environment:
       SUPABASE_URL: http://localhost:3000
-      SUPABASE_ANON_KEY: anon-key
+      SUPABASE_ANON_KEY: ${ANON_KEY}
     ports:
       - "54323:3000"

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,2 @@
+-- Seed data for initial local development
+insert into tags (name) values ('Agave'), ('Cactus') on conflict do nothing;


### PR DESCRIPTION
## Summary
- use environment variables in docker compose for Supabase
- add basic seed SQL for Supabase

## Testing
- `npm test`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19488f78483318b01e0a8ec9eacd3