### PR TITLE
feat: add stock creation API

### DIFF
--- a/__tests__/addStock.test.ts
+++ b/__tests__/addStock.test.ts
@@ -1,0 +1,38 @@
+jest.mock('../offlineQueue', () => ({
+  enqueue: jest.fn(),
+}));
+
+const baseUrl = 'https://example.com';
+process.env.EXPO_PUBLIC_API_BASE_URL = baseUrl;
+
+const { addStock } = require('../api');
+const { enqueue } = require('../offlineQueue');
+
+describe('addStock', () => {
+  beforeEach(() => {
+    (enqueue as jest.Mock).mockClear();
+  });
+
+  it('posts new stock and returns result on success', async () => {
+    const mockResp = { id: 1, name: 'test', parent_id: null };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResp),
+    }) as any;
+
+    const result = await addStock({ name: 'test' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${baseUrl}/api/stocks`,
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(result).toEqual(mockResp);
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it('enqueues request when network fails', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network')); 
+    await addStock({ name: 'offline' });
+    expect(enqueue).toHaveBeenCalled();
+  });
+});

--- a/__tests__/addStock.test.ts
+++ b/__tests__/addStock.test.ts
@@ -13,26 +13,51 @@ describe('addStock', () => {
     (enqueue as jest.Mock).mockClear();
   });
 
-  it('posts new stock and returns result on success', async () => {
+  it('posts new stock with details and returns result on success', async () => {
     const mockResp = { id: 1, name: 'test', parent_id: null };
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(mockResp),
     }) as any;
 
-    const result = await addStock({ name: 'test' });
+    const result = await addStock({
+      name: 'test',
+      tags: ['tag1'],
+      images: ['uri1'],
+    });
 
     expect(fetch).toHaveBeenCalledWith(
       `${baseUrl}/api/stocks`,
-      expect.objectContaining({ method: 'POST' })
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          name: 'test',
+          parent_id: null,
+          is_public: true,
+          tags: ['tag1'],
+          images: ['uri1'],
+        }),
+      })
     );
     expect(result).toEqual(mockResp);
     expect(enqueue).not.toHaveBeenCalled();
   });
 
-  it('enqueues request when network fails', async () => {
-    global.fetch = jest.fn().mockRejectedValue(new Error('network')); 
-    await addStock({ name: 'offline' });
-    expect(enqueue).toHaveBeenCalled();
+  it('enqueues request with details when network fails', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network'));
+    await addStock({ name: 'offline', tags: ['t'], images: ['i'] });
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          body: JSON.stringify({
+            name: 'offline',
+            parent_id: null,
+            is_public: true,
+            tags: ['t'],
+            images: ['i'],
+          }),
+        }),
+      })
+    );
   });
 });

--- a/api.ts
+++ b/api.ts
@@ -55,7 +55,8 @@ export interface NewStockParams {
   name: string;
   parentId?: number;
   isPublic?: boolean;
-  tagIds?: number[];
+  tags?: string[];
+  images?: string[];
 }
 
 export async function addStock(
@@ -71,7 +72,8 @@ export async function addStock(
         name: params.name,
         parent_id: params.parentId ?? null,
         is_public: params.isPublic ?? true,
-        tag_ids: params.tagIds ?? [],
+        tags: params.tags ?? [],
+        images: params.images ?? [],
       }),
     },
   } as const;

--- a/api.ts
+++ b/api.ts
@@ -1,3 +1,5 @@
+import { enqueue } from './offlineQueue';
+
 export interface Stock {
   id: number;
   name: string;
@@ -47,4 +49,41 @@ export async function searchStocks(params: SearchParams): Promise<Stock[]> {
     throw new Error('Failed to search stocks');
   }
   return resp.json();
+}
+
+export interface NewStockParams {
+  name: string;
+  parentId?: number;
+  isPublic?: boolean;
+  tagIds?: number[];
+}
+
+export async function addStock(
+  params: NewStockParams
+): Promise<Stock | undefined> {
+  const op = {
+    id: `${Date.now()}`,
+    url: `${API_BASE_URL}/api/stocks`,
+    options: {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: params.name,
+        parent_id: params.parentId ?? null,
+        is_public: params.isPublic ?? true,
+        tag_ids: params.tagIds ?? [],
+      }),
+    },
+  } as const;
+
+  try {
+    const resp = await fetch(op.url, op.options);
+    if (!resp.ok) {
+      throw new Error('Failed to add stock');
+    }
+    return resp.json();
+  } catch {
+    await enqueue(op);
+    return undefined;
+  }
 }

--- a/app/shelf/[id].tsx
+++ b/app/shelf/[id].tsx
@@ -7,7 +7,6 @@ import {
   TouchableOpacity,
   Image,
   Dimensions,
-  Alert,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useLocalSearchParams, router } from 'expo-router';
@@ -78,19 +77,7 @@ export default function ShelfDetailScreen() {
   const cellSize = (width - 60) / shelf.columns;
 
   const addPlant = (row: number, col: number) => {
-    Alert.alert(
-      '株を追加',
-      '新しい株を追加しますか？',
-      [
-        { text: 'キャンセル' },
-        { 
-          text: '追加', 
-          onPress: () => {
-            console.log('Add plant to position:', row, col);
-          }
-        },
-      ]
-    );
+    router.push(`/stock/new?shelf=${shelf.id}&row=${row}&col=${col}`);
   };
 
   const renderPlantCell = (plant: AgavePlant | null, row: number, col: number) => (

--- a/app/stock/new.tsx
+++ b/app/stock/new.tsx
@@ -1,0 +1,161 @@
+import React, { useState, useMemo } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  TextInput,
+  Alert,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { router } from 'expo-router';
+import { ArrowLeft } from 'lucide-react-native';
+import { addStock } from '../../api';
+import { useTheme } from '../../ThemeContext';
+
+export default function AddStockScreen() {
+  const { colors } = useTheme();
+  const [name, setName] = useState('');
+  const [isPublic, setIsPublic] = useState(true);
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const handleAdd = async () => {
+    if (!name.trim()) {
+      Alert.alert('エラー', '株の名前を入力してください');
+      return;
+    }
+
+    const result = await addStock({ name: name.trim(), isPublic });
+    Alert.alert(
+      result ? '成功' : 'オフライン',
+      result
+        ? '株を追加しました'
+        : 'ネットワークがオフラインのため、株の追加をキューに入れました',
+      [{ text: 'OK', onPress: () => router.back() }]
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity style={styles.backButton} onPress={() => router.back()}>
+          <ArrowLeft size={24} color={colors.primary} />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>株を追加</Text>
+        <TouchableOpacity
+          style={[styles.addButton, !name.trim() && styles.addButtonDisabled]}
+          onPress={handleAdd}
+          disabled={!name.trim()}
+        >
+          <Text
+            style={[
+              styles.addButtonText,
+              !name.trim() && styles.addButtonTextDisabled,
+            ]}
+          >
+            追加
+          </Text>
+        </TouchableOpacity>
+      </View>
+
+      <ScrollView style={styles.content}>
+        <TextInput
+          style={styles.input}
+          placeholder="株の名前"
+          value={name}
+          onChangeText={setName}
+          placeholderTextColor={colors.secondary}
+        />
+
+        <TouchableOpacity
+          style={styles.visibilityToggle}
+          onPress={() => setIsPublic(!isPublic)}
+        >
+          <View style={[styles.toggleDot, isPublic && styles.toggleDotActive]} />
+          <Text style={styles.visibilityText}>
+            {isPublic ? '公開' : '非公開'}
+          </Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+function createStyles(colors: any) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: 20,
+      paddingVertical: 16,
+      backgroundColor: colors.card,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.border,
+    },
+    backButton: {
+      padding: 8,
+      marginRight: 12,
+    },
+    headerTitle: {
+      flex: 1,
+      fontSize: 20,
+      fontWeight: '600',
+      color: colors.text,
+    },
+    addButton: {
+      paddingHorizontal: 16,
+      paddingVertical: 6,
+      borderRadius: 16,
+      backgroundColor: colors.primary,
+    },
+    addButtonDisabled: {
+      backgroundColor: colors.border,
+    },
+    addButtonText: {
+      color: '#ffffff',
+      fontSize: 16,
+      fontWeight: '600',
+    },
+    addButtonTextDisabled: {
+      color: colors.secondary,
+    },
+    content: {
+      flex: 1,
+      padding: 20,
+    },
+    input: {
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: 8,
+      padding: 12,
+      fontSize: 16,
+      color: colors.text,
+      backgroundColor: colors.card,
+    },
+    visibilityToggle: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+      padding: 12,
+    },
+    toggleDot: {
+      width: 20,
+      height: 20,
+      borderRadius: 10,
+      backgroundColor: colors.border,
+    },
+    toggleDotActive: {
+      backgroundColor: colors.primary,
+    },
+    visibilityText: {
+      fontSize: 16,
+      color: colors.text,
+    },
+  });
+}
+

--- a/app/stock/new.tsx
+++ b/app/stock/new.tsx
@@ -7,26 +7,121 @@ import {
   TouchableOpacity,
   TextInput,
   Alert,
+  Image,
+  Dimensions,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
-import { ArrowLeft } from 'lucide-react-native';
+import { ArrowLeft, Camera, Image as ImageIcon, X, Hash } from 'lucide-react-native';
+import * as ImagePicker from 'expo-image-picker';
 import { addStock } from '../../api';
 import { useTheme } from '../../ThemeContext';
+
+const { width } = Dimensions.get('window');
+
+interface StockImage {
+  id: string;
+  uri: string;
+}
 
 export default function AddStockScreen() {
   const { colors } = useTheme();
   const [name, setName] = useState('');
   const [isPublic, setIsPublic] = useState(true);
+  const [images, setImages] = useState<StockImage[]>([]);
+  const [tags, setTags] = useState('');
   const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      aspect: [4, 3],
+      quality: 0.8,
+    });
+
+    if (!result.canceled && result.assets[0]) {
+      const newImage: StockImage = {
+        id: Date.now().toString(),
+        uri: result.assets[0].uri,
+      };
+      setImages([...images, newImage]);
+    }
+  };
+
+  const takePhoto = async () => {
+    const result = await ImagePicker.launchCameraAsync({
+      allowsEditing: true,
+      aspect: [4, 3],
+      quality: 0.8,
+    });
+
+    if (!result.canceled && result.assets[0]) {
+      const newImage: StockImage = {
+        id: Date.now().toString(),
+        uri: result.assets[0].uri,
+      };
+      setImages([...images, newImage]);
+    }
+  };
+
+  const removeImage = (id: string) => {
+    setImages(images.filter(img => img.id !== id));
+  };
+
+  const renderImageGrid = () => {
+    if (images.length === 0) return null;
+
+    const imageSize = images.length === 1 ? width - 40 : (width - 52) / 2;
+
+    return (
+      <View style={styles.imageGrid}>
+        {images.map((image, index) => (
+          <View
+            key={image.id}
+            style={[
+              styles.imageContainer,
+              {
+                width: imageSize,
+                height: imageSize * 0.75,
+                marginBottom: images.length > 2 && index < 2 ? 6 : 0,
+                marginRight: images.length > 1 && index % 2 === 0 ? 6 : 0,
+              },
+            ]}
+          >
+            <Image source={{ uri: image.uri }} style={styles.selectedImage} />
+            <TouchableOpacity
+              style={styles.removeImageButton}
+              onPress={() => removeImage(image.id)}
+            >
+              <X size={16} color="#ffffff" />
+            </TouchableOpacity>
+          </View>
+        ))}
+      </View>
+    );
+  };
 
   const handleAdd = async () => {
     if (!name.trim()) {
       Alert.alert('エラー', '株の名前を入力してください');
       return;
     }
+    if (images.length === 0) {
+      Alert.alert('エラー', '株の画像を追加してください');
+      return;
+    }
+    const tagList = tags
+      .split(',')
+      .map(t => t.trim())
+      .filter(Boolean);
 
-    const result = await addStock({ name: name.trim(), isPublic });
+    const result = await addStock({
+      name: name.trim(),
+      isPublic,
+      tags: tagList,
+      images: images.map(img => img.uri),
+    });
     Alert.alert(
       result ? '成功' : 'オフライン',
       result
@@ -44,14 +139,18 @@ export default function AddStockScreen() {
         </TouchableOpacity>
         <Text style={styles.headerTitle}>株を追加</Text>
         <TouchableOpacity
-          style={[styles.addButton, !name.trim() && styles.addButtonDisabled]}
+          style={[
+            styles.addButton,
+            (!name.trim() || images.length === 0) && styles.addButtonDisabled,
+          ]}
           onPress={handleAdd}
-          disabled={!name.trim()}
+          disabled={!name.trim() || images.length === 0}
         >
           <Text
             style={[
               styles.addButtonText,
-              !name.trim() && styles.addButtonTextDisabled,
+              (!name.trim() || images.length === 0) &&
+                styles.addButtonTextDisabled,
             ]}
           >
             追加
@@ -67,6 +166,30 @@ export default function AddStockScreen() {
           onChangeText={setName}
           placeholderTextColor={colors.secondary}
         />
+
+        <View style={styles.imageButtons}>
+          <TouchableOpacity style={styles.imageButton} onPress={pickImage}>
+            <ImageIcon size={20} color={colors.text} />
+            <Text style={styles.imageButtonText}>ギャラリー</Text>
+          </TouchableOpacity>
+          <TouchableOpacity style={styles.imageButton} onPress={takePhoto}>
+            <Camera size={20} color={colors.text} />
+            <Text style={styles.imageButtonText}>カメラ</Text>
+          </TouchableOpacity>
+        </View>
+
+        {renderImageGrid()}
+
+        <View style={styles.tagInputContainer}>
+          <Hash size={16} color={colors.secondary} />
+          <TextInput
+            style={styles.tagInput}
+            placeholder="タグ (カンマ区切り)"
+            value={tags}
+            onChangeText={setTags}
+            placeholderTextColor={colors.secondary}
+          />
+        </View>
 
         <TouchableOpacity
           style={styles.visibilityToggle}
@@ -156,6 +279,60 @@ function createStyles(colors: any) {
       fontSize: 16,
       color: colors.text,
     },
+    imageButtons: {
+      flexDirection: 'row',
+      gap: 12,
+      marginTop: 20,
+    },
+    imageButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      padding: 10,
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: 8,
+    },
+    imageButtonText: {
+      color: colors.text,
+    },
+    imageGrid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      marginTop: 12,
+    },
+    imageContainer: {
+      position: 'relative',
+    },
+    selectedImage: {
+      width: '100%',
+      height: '100%',
+      borderRadius: 8,
+    },
+    removeImageButton: {
+      position: 'absolute',
+      top: 4,
+      right: 4,
+      backgroundColor: 'rgba(0, 0, 0, 0.7)',
+      borderRadius: 10,
+      padding: 2,
+    },
+    tagInputContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      borderWidth: 1,
+      borderColor: colors.border,
+      borderRadius: 8,
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      marginTop: 20,
+      backgroundColor: colors.card,
+    },
+    tagInput: {
+      flex: 1,
+      fontSize: 16,
+      color: colors.text,
+      marginLeft: 6,
+    },
   });
 }
-


### PR DESCRIPTION
## Summary
- add API to create stocks
- queue stock creation when network is unavailable
- cover stock creation with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1a3c8620c8331b094622d057a767a